### PR TITLE
ENG-54380: Invalid text input field validation for configuration name in Configuration Details workflow

### DIFF
--- a/projects/configuration_details/configuration_details_ui/src/pages/configurationDetails/App.js
+++ b/projects/configuration_details/configuration_details_ui/src/pages/configurationDetails/App.js
@@ -52,12 +52,7 @@ import {
     TableToolbar,
     TableToolbarDefault,
 } from '@bluecateng/pelagos';
-import {
-    Form,
-    validateAnd,
-    validateMatches,
-    validateNotEmpty,
-} from '@bluecateng/auto-forms';
+import { Form, validateNotEmpty } from '@bluecateng/auto-forms';
 import { FormSubmit, FormTextInput } from '@bluecateng/pelagos-forms';
 import './App.less';
 
@@ -109,7 +104,7 @@ const Content = () => {
 
     // Rules for the add Configuration panel
     const configurationRules = {
-        name: validateNotEmpty('The configuration name is required.')
+        name: validateNotEmpty('The configuration name is required.'),
     };
 
     const closeAllPanelsAndSetValuesToDefault = () => {


### PR DESCRIPTION
- Following investigation of BAM, it was discovered that there is no validation of the content of the configuration name.
- Regex for characters in config name was removed
- Note: In BAM, leading and trailing whitespace in configuration names is acceptable. API strips leading/trailing whitespace.