### PR TITLE
ENG-54383: Add/Update/Delete new UI example workflows wont't work with case-sensitive names for configuration, view, zone.

### DIFF
--- a/projects/add_text_record/add_text_record_ui/src/hooks/useObjectSuggestions.js
+++ b/projects/add_text_record/add_text_record_ui/src/hooks/useObjectSuggestions.js
@@ -33,9 +33,9 @@ export default (values, setError, errorText, disable) => {
                 return [];
             }
 
-            const text_lower = text.toLowerCase();
+            const textLower = text.toLowerCase();
             const suggestions = names.filter(({ name }) =>
-                name.toLowerCase().includes(text_lower),
+                name.toLowerCase().includes(textLower),
             );
             if (!suggestions.length) {
                 setError(errorText);
@@ -46,8 +46,8 @@ export default (values, setError, errorText, disable) => {
                 .sort((a, b) => {
                     const an = a.name;
                     const bn = b.name;
-                    const as = an.toLowerCase().startsWith(text_lower);
-                    const bs = bn.toLowerCase().startsWith(text_lower);
+                    const as = an.toLowerCase().startsWith(textLower);
+                    const bs = bn.toLowerCase().startsWith(textLower);
                     return bs - as || an.localeCompare(bn);
                 })
                 .map(({ id, name }) => ({ id, name }));

--- a/projects/manage_text_record/manage_text_record_ui/src/hooks/useObjectSuggestions.js
+++ b/projects/manage_text_record/manage_text_record_ui/src/hooks/useObjectSuggestions.js
@@ -24,7 +24,7 @@ import { useCallback, useMemo } from 'react';
 
 export default (values, setError, errorText, disable) => {
     const names = useMemo(
-        () => values.map(({ id, name }) => ({ id, name: name.toLowerCase() })),
+        () => values.map(({ id, name }) => ({ id, name })),
         [values],
     );
     return useCallback(
@@ -33,8 +33,10 @@ export default (values, setError, errorText, disable) => {
                 return [];
             }
 
-            text = text.toLowerCase();
-            const suggestions = names.filter(({ name }) => name.includes(text));
+            const textLower = text.toLowerCase();
+            const suggestions = names.filter(({ name }) =>
+                name.toLowerCase().includes(textLower),
+            );
             if (!suggestions.length) {
                 setError(errorText);
                 return suggestions;
@@ -44,8 +46,8 @@ export default (values, setError, errorText, disable) => {
                 .sort((a, b) => {
                     const an = a.name;
                     const bn = b.name;
-                    const as = an.startsWith(text);
-                    const bs = bn.startsWith(text);
+                    const as = an.toLowerCase().startsWith(textLower);
+                    const bs = bn.toLowerCase().startsWith(textLower);
                     return bs - as || an.localeCompare(bn);
                 })
                 .map(({ id, name }) => ({ id, name }));


### PR DESCRIPTION
- Configurations/zones/views with capital letters were unselectable in add/update/delete text record wf
- Suggestions generated from text in config/view/zone field would return lowercase of all matching configurations
- I.e. searching for "Test Config 1" would yield a suggestion "test config 1". These do not match, therefore Test Config 1 is not selectable
- Search results are no longer converted to lowercase, results are case-insensitive