### PR TITLE
ENG-54531: Text records are not displayed in Update/Delete Text Record workflow when a text record which has the same name as the zone is present

### DIFF
--- a/projects/manage_text_record/manage_text_record_ui/src/pages/deleteTextRecord/FormFields.js
+++ b/projects/manage_text_record/manage_text_record_ui/src/pages/deleteTextRecord/FormFields.js
@@ -138,7 +138,12 @@ export const FormFields = ({ initialFormData }) => {
 
             doPost('/manage_text_record/delete_text_record/records', payload)
                 .then((data) => {
-                    setRecords(data.records.length === 0 ? [] : data.records);
+                    data.records.map(
+                        (rec) =>
+                            (rec.displayName = rec.name
+                                ? rec.name
+                                : 'Same as zone named text record'),
+                    );
                     setRecords(data.records.length === 0 ? [] : data.records);
                 })
                 .finally(() => {
@@ -153,11 +158,15 @@ export const FormFields = ({ initialFormData }) => {
         if (filterText.length !== 0 && records.length !== 0) {
             setSelectedRecord({});
             setFilteredRecords(
-                records.filter((rec) => rec.name.includes(filterText)),
+                records.filter((rec) =>
+                    rec.displayName.toLowerCase().includes(filterText),
+                ),
             );
         } else {
             setFilteredRecords(
-                records.filter((rec) => rec.name.includes(filterText)),
+                records.filter((rec) =>
+                    rec.displayName.toLowerCase().includes(filterText),
+                ),
             );
         }
     }, [records, filterText]);
@@ -257,7 +266,7 @@ export const FormFields = ({ initialFormData }) => {
                                                     selectedRecord?.id
                                                 }>
                                                 <TableCell>
-                                                    {value.name}
+                                                    {value.displayName}
                                                 </TableCell>
                                             </TableRow>
                                         );

--- a/projects/manage_text_record/manage_text_record_ui/src/pages/updateTextRecord/FormFields.js
+++ b/projects/manage_text_record/manage_text_record_ui/src/pages/updateTextRecord/FormFields.js
@@ -145,7 +145,12 @@ export const FormFields = ({ initialFormData }) => {
 
             doPost('/manage_text_record/update_text_record/records', payload)
                 .then((data) => {
-                    data.records.map((rec) => (rec.displayName = rec.name ? rec.name : "Same as zone named text record"))
+                    data.records.map(
+                        (rec) =>
+                            (rec.displayName = rec.name
+                                ? rec.name
+                                : 'Same as zone named text record'),
+                    );
                     setRecords(data.records.length === 0 ? [] : data.records);
                 })
                 .finally(() => {
@@ -162,11 +167,15 @@ export const FormFields = ({ initialFormData }) => {
         if (filterText.length !== 0 && records.length !== 0) {
             setSelectedRecord({});
             setFilteredRecords(
-                records.filter((rec) => rec.displayName.toLowerCase().includes(filterText)),
+                records.filter((rec) =>
+                    rec.displayName.toLowerCase().includes(filterText),
+                ),
             );
         } else {
             setFilteredRecords(
-                records.filter((rec) => rec.displayName.toLowerCase().includes(filterText)),
+                records.filter((rec) =>
+                    rec.displayName.toLowerCase().includes(filterText),
+                ),
             );
         }
         setSelectedRecordName('');


### PR DESCRIPTION
- A record with the same name as the zone a `null` valued name when getting an array of resource records via BAM rest apiv2
- Added a `displayName` for each record such that a record with a `null` name can be assigned a display name that is intuitive to the user
- 
<img width="737" alt="Screen Shot 2024-04-03 at 3 22 55 PM" src="https://github.com/bluecatlabs/bluecat-example-workflows/assets/157743396/41469df6-4fbd-4702-905b-aafaa46e9234">
