### PR TITLE
ENG-55379: (#2) Update text record workflow is not functioning as expected

### DIFF
--- a/projects/manage_text_record/manage_text_record_ui/src/pages/updateTextRecord/App.js
+++ b/projects/manage_text_record/manage_text_record_ui/src/pages/updateTextRecord/App.js
@@ -93,11 +93,6 @@ const Content = () => {
         setBusy(true);
         doPost('/manage_text_record/update_text_record/update', payload)
             .then((data) => {
-                /*
-                const keys = Object.keys(data)
-                if(keys.length === 1 && keys[0] === 'error')
-                    throw new Error(data[keys[0]])
-                */
                 addMessages([{ 'type': 'success', 'text': data.message }]);
                 toggleTriggerLoad();
             })

--- a/workspace/workflows/manage_text_record/routes.py
+++ b/workspace/workflows/manage_text_record/routes.py
@@ -159,7 +159,7 @@ def api_post_update_text_record():
     }
 
     try:
-        g.user.bam_api.v2.http_put(
+        rdata = g.user.bam_api.v2.http_put(
             f"/resourceRecords/{record_id}",
             headers=headers,
             params={},
@@ -170,6 +170,7 @@ def api_post_update_text_record():
 
     return {
         "message": "Record successfully updated",
+        "data": rdata,
     }
 
 


### PR DESCRIPTION
- Change `api_post_update_text_record` to throw error via `api_exc_handler` instead of return statement
- Change frontend validation to validate `displayName` instead of `name` for the fields